### PR TITLE
2 repl

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Interact with a Ditto database.
 Usage: dto [OPTIONS] [COMMAND]
 
 Commands:
-  repl         Simple REPL interface for interacting with Ditto data
   collections  View Ditto's local collections for your App ID
   configure    Create or show dto's configuration file
   execute      Execute a single synchronous query for a given configured APP ID

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,8 +53,8 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Simple REPL interface for interacting with Ditto data
-    Repl {},
+    // /// Simple REPL interface for interacting with Ditto data
+    // Repl {},
     /// View Ditto's local collections for your App ID
     Collections {},
     /// Create or show dto's configuration file
@@ -191,9 +191,10 @@ fn main() -> anyhow::Result<()> {
     let store = ditto.store();
 
     match &cli.command {
-        Some(Commands::Repl {}) => {
-            let _repl = start_repl(ditto);
-        }
+        // Pausing dev on the REPL until have working inserts from execute command
+        // Some(Commands::Repl {}) => {
+        //     let _repl = start_repl(ditto);
+        // }
         Some(Commands::Collections {}) => {
             collection::list_collections(store);
         }


### PR DESCRIPTION
Closes #2 by removing the REPL command from the options.  Initial code is still in the repo.